### PR TITLE
panic instead of returning error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/grandecola/mmap
 
 go 1.12
-
-require golang.org/x/sys v0.0.0-20190311152110-c8c8c57fd1e1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/sys v0.0.0-20190311152110-c8c8c57fd1e1 h1:FQNj2xvjQ1lgFyzbSybGZr792Y8Dy95D7uuqnZAzNaA=
-golang.org/x/sys v0.0.0-20190311152110-c8c8c57fd1e1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/immap.go
+++ b/immap.go
@@ -10,8 +10,8 @@ type IMmap interface {
 	Lock() error
 	Unlock() error
 	Advise(advice int) error
-	ReadUint64At(offset int64) (uint64, error)
-	WriteUint64At(num uint64, offset int64) error
+	ReadUint64At(offset int64) uint64
+	WriteUint64At(num uint64, offset int64)
 	Flush(flags int) error
 	Unmap() error
 }

--- a/mmap.go
+++ b/mmap.go
@@ -3,8 +3,7 @@ package mmap
 import (
 	"errors"
 	"os"
-
-	"golang.org/x/sys/unix"
+	"syscall"
 )
 
 var (
@@ -28,7 +27,7 @@ type Mmap struct {
 //    case 2 => if   file size <= memory region (offset + length)
 //              then from offset to file size memory region is accessible
 func NewSharedFileMmap(f *os.File, offset int64, length int, prot int) (IMmap, error) {
-	data, err := unix.Mmap(int(f.Fd()), offset, length, prot, unix.MAP_SHARED)
+	data, err := syscall.Mmap(int(f.Fd()), offset, length, prot, syscall.MAP_SHARED)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +41,7 @@ func NewSharedFileMmap(f *os.File, offset int64, length int, prot int) (IMmap, e
 // Unmap unmaps the memory mapped file. An error will be returned
 // if any of the functions are called on Mmap after calling Unmap
 func (m *Mmap) Unmap() error {
-	err := unix.Munmap(m.data)
+	err := syscall.Munmap(m.data)
 	m.data = nil
 	return err
 }

--- a/mmap_data.go
+++ b/mmap_data.go
@@ -13,11 +13,12 @@ import (
 //        => copies (len(m.data) - offset) bytes to dest from mapped region
 //   Case 2: len(dest) < (len(m.data) - offset)
 //        => copies len(dest) bytes to dest from mapped region
+// err is always nil, hence, can be ignored
 func (m *Mmap) ReadAt(dest []byte, offset int64) (int, error) {
 	if m.data == nil {
-		return 0, ErrUnmappedMemory
+		panic(ErrUnmappedMemory)
 	} else if offset >= m.length || offset < 0 {
-		return 0, ErrIndexOutOfBound
+		panic(ErrIndexOutOfBound)
 	}
 
 	return copy(dest, m.data[offset:]), nil
@@ -30,37 +31,37 @@ func (m *Mmap) ReadAt(dest []byte, offset int64) (int, error) {
 //      => copies (len(m.data) - offset) bytes to the mapped region from src
 //  Case 2: len(src) < (len(m.data) - offset)
 //      => copies len(src) bytes to the mapped region from src
+// err is always nil, hence, can be ignored
 func (m *Mmap) WriteAt(src []byte, offset int64) (int, error) {
 	if m.data == nil {
-		return 0, ErrUnmappedMemory
+		panic(ErrUnmappedMemory)
 	} else if offset >= m.length || offset < 0 {
-		return 0, ErrIndexOutOfBound
+		panic(ErrIndexOutOfBound)
 	}
 
 	return copy(m.data[offset:], src), nil
 }
 
 // ReadUint64At reads uint64 from offset
-func (m *Mmap) ReadUint64At(offset int64) (uint64, error) {
+func (m *Mmap) ReadUint64At(offset int64) uint64 {
 	if m.data == nil {
-		return 0, ErrUnmappedMemory
+		panic(ErrUnmappedMemory)
 	} else if offset+8 > m.length || offset < 0 {
-		return 0, ErrIndexOutOfBound
+		panic(ErrIndexOutOfBound)
 	}
 
-	return binary.LittleEndian.Uint64(m.data[offset : offset+8]), nil
+	return binary.LittleEndian.Uint64(m.data[offset : offset+8])
 }
 
 // WriteUint64At writes num at offset
-func (m *Mmap) WriteUint64At(num uint64, offset int64) error {
+func (m *Mmap) WriteUint64At(num uint64, offset int64) {
 	if m.data == nil {
-		return ErrUnmappedMemory
+		panic(ErrUnmappedMemory)
 	} else if offset+8 > m.length || offset < 0 {
-		return ErrIndexOutOfBound
+		panic(ErrIndexOutOfBound)
 	}
 
 	binary.LittleEndian.PutUint64(m.data[offset:offset+8], num)
-	return nil
 }
 
 // Flush flushes the memory mapped region to disk

--- a/mmap_data.go
+++ b/mmap_data.go
@@ -2,8 +2,8 @@ package mmap
 
 import (
 	"encoding/binary"
-
-	"golang.org/x/sys/unix"
+	"syscall"
+	"unsafe"
 )
 
 // ReadAt copies data to dest slice from mapped region starting at
@@ -66,5 +66,11 @@ func (m *Mmap) WriteUint64At(num uint64, offset int64) {
 
 // Flush flushes the memory mapped region to disk
 func (m *Mmap) Flush(flags int) error {
-	return unix.Msync(m.data, flags)
+	_, _, err := syscall.Syscall(syscall.SYS_MSYNC,
+		uintptr(unsafe.Pointer(&m.data[0])), uintptr(len(m.data)), uintptr(flags))
+	if err != 0 {
+		return err
+	}
+
+	return nil
 }

--- a/mmap_page.go
+++ b/mmap_page.go
@@ -1,20 +1,39 @@
 package mmap
 
 import (
-	"golang.org/x/sys/unix"
+	"syscall"
+	"unsafe"
 )
 
 // Advise provides hints to kernel regarding the use of memory mapped region
 func (m *Mmap) Advise(advice int) error {
-	return unix.Madvise(m.data, advice)
+	_, _, err := syscall.Syscall(syscall.SYS_MADVISE,
+		uintptr(unsafe.Pointer(&m.data[0])), uintptr(len(m.data)), uintptr(advice))
+	if err != 0 {
+		return err
+	}
+
+	return nil
 }
 
 // Lock locks all the mapped memory to RAM, preventing the pages from swapping out
 func (m *Mmap) Lock() error {
-	return unix.Mlock(m.data)
+	_, _, err := syscall.Syscall(syscall.SYS_MLOCK,
+		uintptr(unsafe.Pointer(&m.data[0])), uintptr(len(m.data)), 0)
+	if err != 0 {
+		return err
+	}
+
+	return nil
 }
 
 // Unlock unlocks the mapped memory from RAM, enabling swapping out of RAM if required
 func (m *Mmap) Unlock() error {
-	return unix.Munlock(m.data)
+	_, _, err := syscall.Syscall(syscall.SYS_MUNLOCK,
+		uintptr(unsafe.Pointer(&m.data[0])), uintptr(len(m.data)), 0)
+	if err != 0 {
+		return err
+	}
+
+	return nil
 }

--- a/mmap_test.go
+++ b/mmap_test.go
@@ -5,13 +5,12 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"syscall"
 	"testing"
-
-	"golang.org/x/sys/unix"
 )
 
 var (
-	protPage = unix.PROT_READ | unix.PROT_WRITE
+	protPage = syscall.PROT_READ | syscall.PROT_WRITE
 	testData = []byte("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	testPath = "/tmp/m.txt"
 )
@@ -110,7 +109,7 @@ func TestReadWrite(t *testing.T) {
 	if _, err := m.WriteAt([]byte("a"), 9); err != nil {
 		t.Fatalf("error in writing to mapped area :: %v", err)
 	}
-	if err := m.Flush(unix.MS_SYNC); err != nil {
+	if err := m.Flush(syscall.MS_SYNC); err != nil {
 		t.Fatalf("error in calling flush :: %v", err)
 	}
 	f1, errFile := os.OpenFile(testPath, os.O_RDWR, 0644)
@@ -130,7 +129,7 @@ func TestReadWrite(t *testing.T) {
 	if _, err := m.WriteAt([]byte("abc"), 34); err != nil {
 		t.Fatalf("error in writing to mapped region :: %v", err)
 	}
-	if err := m.Flush(unix.MS_SYNC); err != nil {
+	if err := m.Flush(syscall.MS_SYNC); err != nil {
 		t.Fatalf("error in flushing mapped region :: %v", err)
 	}
 	f2, err := os.OpenFile(testPath, os.O_RDWR, 0644)
@@ -181,7 +180,7 @@ func TestAdvise(t *testing.T) {
 		}
 	}()
 
-	if err := m.Advise(unix.MADV_SEQUENTIAL); err != nil {
+	if err := m.Advise(syscall.MADV_SEQUENTIAL); err != nil {
 		t.Fatalf("error in calling advise :: %v", err)
 	}
 }
@@ -411,7 +410,7 @@ func TestIOInterfaces(t *testing.T) {
 	if _, err := m.WriteAt(zipData, 0); err != nil {
 		t.Fatalf("error in writing to file :: %v", err)
 	}
-	if err := m.Flush(unix.MS_SYNC); err != nil {
+	if err := m.Flush(syscall.MS_SYNC); err != nil {
 		t.Fatalf("error in calling sync :: %v", err)
 	}
 


### PR DESCRIPTION
There are currently two cases where we used to return an error -
 * When mapped region is unmaped: this is unusual case and it makes sense to panic instead of returning error.
 * When an offset beyond mapped region is read/written: this may occur in usual scenarios but panic is okay here too.

This simplifies the interface for reading and writing uint64 and avoids checking for errors.